### PR TITLE
Modify the datatype for ilk

### DIFF
--- a/src/ClaimFee.sol
+++ b/src/ClaimFee.sol
@@ -517,7 +517,7 @@ contract ClaimFee {
     /// @param issuance Issuance timestamp
     /// @param maturity Maturity timestamp
     /// @return class_ Calculated class value
-    function getClass(string calldata ilk, uint256 issuance, uint256 maturity) public pure returns (bytes32 class_) {
-        class_ = keccak256(abi.encodePacked(bytes32(bytes(ilk)), issuance, maturity));
+    function getClass(bytes32 ilk, uint256 issuance, uint256 maturity) public pure returns (bytes32 class_) {
+        class_ = keccak256(abi.encodePacked(ilk, issuance, maturity));
     }
 }


### PR DESCRIPTION
Based on Chainlink security audit, item # 6.1

The current implementation of explicit type conversion is not allowed. 

`Error : Explicit type conversion not allowed from "bytes calldata" to "bytes32". `

If its purpose is to be used by either UX or other contracts, they can leverage this https://github.com/dapphub/dapptools/tree/master/src/seth library to encode/decode. Would love to hear your thoughts.